### PR TITLE
Update Dockerfile.cu121.mlc

### DIFF
--- a/docker/Dockerfile.cu121.mlc
+++ b/docker/Dockerfile.cu121.mlc
@@ -14,7 +14,7 @@ RUN apt update                                                          && \
 
 RUN bash <(curl -L micro.mamba.pm/install.sh) && source ~/.bashrc       && \
     micromamba create --yes -n python311 -c conda-forge                    \
-    python=3.11 pytorch-cpu                                             && \
+    python=3.11 pytorch-cpu git-lfs                                            && \
     micromamba activate python311                                       && \
     pip install --pre --force-reinstall -f https://mlc.ai/wheels           \
                 mlc-ai-nightly-cu121                                       \


### PR DESCRIPTION
avoid error:
unable to build: _pickle.UnpicklingError: invalid load key, 'v'
![image](https://github.com/mlc-ai/llm-perf-bench/assets/54315206/aa28638d-705e-42c1-8ea1-dd49ab0a6642)
