### PR TITLE
vllm upgrade to CUDA12

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ git clone https://huggingface.co/TheBloke/Llama-2-7B-fp16
 # You can also git clone awq models, e.g.
 # git clone https://huggingface.co/TheBloke/Llama-2-70B-AWQ
 docker build --no-cache -t llm-perf-vllm:v0.1    \
-    -f ./docker/Dockerfile.cu118.vllm .
+    -f ./docker/Dockerfile.cu121q.vllm .
 ./docker/bash.sh llm-perf-vllm:v0.1
 conda activate python311
 ```

--- a/docker/Dockerfile.cu121.vllm
+++ b/docker/Dockerfile.cu121.vllm
@@ -1,6 +1,6 @@
-# NOTE: This Dockerfile is based on CUDA 11.8.
-# To benchmark on other CUDA versions, search and replace "11.8" and "118".
-FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
+# NOTE: This Dockerfile is based on CUDA 12.1.
+# To benchmark on other CUDA versions, search and replace "12.1" and "121".
+FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
 
 SHELL ["/bin/bash", "-ec"]
 
@@ -16,8 +16,6 @@ RUN bash <(curl -L micro.mamba.pm/install.sh) && source ~/.bashrc       && \
     micromamba create --yes -n python311 -c conda-forge python=3.11
 
 RUN git clone https://github.com/vllm-project/vllm.git /vllm             && \
-    sed -i 's/torch >= 2.0.0/torch == 2.0.1/' /vllm/pyproject.toml             && \
-    sed -i 's/torch >= 2.0.0/torch == 2.0.1/' /vllm/requirements.txt           && \
     echo "export PYTHONPATH=\"/vllm/:$PYTHONPATH\"" >> ~/.bashrc
 
 


### PR DESCRIPTION
vLLM now use CUDA12.


Also, I can't confirm your results on RTX 3090

mcl-llm
```
Statistics: ----------- prefill -----------
throughput: 218.2 tok/s
total tokens: 7 tok
total time: 0.0 s
------------ decode ------------
throughput: 170.7 tok/s
total tokens: 256 tok
total time: 1.5 s
```

vllm(when use 4-bit AWQ model)
```
Avg latency: 1.4600699121753375 seconds
Speed: 175.33 tok/s
Speed: 0.00570 s/tok

```