### PR TITLE
Update Dockerfile.cu121.mlc

### DIFF
--- a/docker/Dockerfile.cu121.mlc
+++ b/docker/Dockerfile.cu121.mlc
@@ -18,7 +18,7 @@ RUN bash <(curl -L micro.mamba.pm/install.sh) && source ~/.bashrc       && \
     micromamba activate python311                                       && \
     pip install --pre --force-reinstall -f https://mlc.ai/wheels           \
                 mlc-ai-nightly-cu121                                       \
-                mlc-chat-nightly-cu121
+                mlc-llm-nightly-cu121
 
 RUN git clone https://github.com/mlc-ai/mlc-llm.git /mlc_llm             && \
     echo "export PYTHONPATH=\"/mlc_llm/:$PYTHONPATH\"" >> ~/.bashrc


### PR DESCRIPTION
Hi @junrushao, 

It appears that 'mlc-chat' is a deprecated package name, so I've updated it accordingly.


```
ERROR: Could not find a version that satisfies the requirement mlc-chat-nightly-cu121 (from versions: none)
ERROR: No matching distribution found for mlc-chat-nightly-cu121
```

